### PR TITLE
Fixes recursion and providing the correct module data.

### DIFF
--- a/require.js
+++ b/require.js
@@ -43,20 +43,20 @@
 
   var initModule = function(name, definition) {
     var module = {id: name, exports: {}};
+    cache[name] = module;
     definition(module.exports, localRequire(name), module);
-    var exports = cache[name] = module.exports;
-    return exports;
+    return module.exports;
   };
 
   var require = function(name, loaderPath) {
     var path = expand(name, '.');
     if (loaderPath == null) loaderPath = '/';
 
-    if (has(cache, path)) return cache[path];
+    if (has(cache, path)) return cache[path].exports;
     if (has(modules, path)) return initModule(path, modules[path]);
 
     var dirIndex = expand(path, './index');
-    if (has(cache, dirIndex)) return cache[dirIndex];
+    if (has(cache, dirIndex)) return cache[dirIndex].exports;
     if (has(modules, dirIndex)) return initModule(dirIndex, modules[dirIndex]);
 
     throw new Error('Cannot find module "' + name + '" from '+ '"' + loaderPath + '"');


### PR DESCRIPTION
This fix allows for two modules to require each other the way Node.js does. By putting the module object in the cache instead of its exports object we allow for returning the correct module.exports even before the initModule function returns.

Example:

some-class.js

```
function SomeClass() {

}
SomeClass.prototype.doSomething = function() {
  return new AnotherClass()
};
module.exports = SomeClass;
var AnotherClass = require('./another-class');
```

another-class.js

```
function AnotherClass() {

}
AnotherClass.prototype.doSomethingElse = function() {
  return new SomeClass()
};
module.exports = AnotherClass;
var SomeClass = require('./some-class');
```

Currently this results in a Maximum Call Stack Exceeded error. Adding the exports to the cache before calling definition() fixes the recursion, but doesn't provide the correct module.exports inside the recursion. But placing the module in the cache and returning cache[name].exports will always return the correct module at the given point in code. And this is the same behavior as Node.js.

Could you please bump and publish to NPM? Thank you!
