### PR TITLE
Expose the cache

### DIFF
--- a/require.js
+++ b/require.js
@@ -107,5 +107,6 @@
   };
 
   require.brunch = true;
+  require._cache = cache;
   globals.require = require;
 })();


### PR DESCRIPTION
It's sometimes convenient, particularly for unit testing purpose, to be able to require a module without having it's definition cached. This PR just expose it in the same way that Node require does it.

Not sure it's worth to document though, let me know and I’ll amend the PR.