### PR TITLE
Fix a typo in extension regexp variable name

### DIFF
--- a/require.js
+++ b/require.js
@@ -60,8 +60,8 @@
   var indexRe = /\/index(\.[^\/]+)?$/;
   var addExtensions = function(bundle) {
     var alias = bundle;
-    while (extExp.test(alias)) {
-      alias = alias.replace(extExp, '');
+    while (extRe.test(alias)) {
+      alias = alias.replace(extRe, '');
       if (!has.call(aliases, alias) || aliases[alias].replace(extRe, '') === alias + '/index') {
         aliases[alias] = bundle;
       }

--- a/require.js
+++ b/require.js
@@ -62,7 +62,7 @@
     var alias = bundle;
     while (extRe.test(alias)) {
       alias = alias.replace(extRe, '');
-      if (!has.call(aliases, alias) || aliases[alias].replace(extRe, '') === alias + '/index') {
+      if (!has.call(aliases, alias) || aliases[alias].replace(extRe, '') === alias + '/index' || bundle === alias + '.js') {
         aliases[alias] = bundle;
       }
     }


### PR DESCRIPTION
Introduces by https://github.com/brunch/commonjs-require-definition/commit/f5b2ed3047dde29399bea4f38693364ba6e170aa