### PR TITLE
Add support for web workers and service workers

### DIFF
--- a/require.js
+++ b/require.js
@@ -1,7 +1,7 @@
 (function() {
   'use strict';
 
-  var globals = typeof window === 'undefined' ? global : window;
+  var globals = typeof window === 'undefined' ? (typeof self === 'undefined' ? global : self) : window;
   if (typeof globals.require === 'function') return;
 
   var modules = {};


### PR DESCRIPTION
If `window` is not defined, the environment may be either Node or web / service
workers. `self` is used to reference the global scope in a worker environment.

I ran into this issue when using Brunch with a service worker.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/brunch/commonjs-require-definition/24)
<!-- Reviewable:end -->
