### PR TITLE
Avoid self-referential aliases

### DIFF
--- a/require.js
+++ b/require.js
@@ -44,7 +44,7 @@
   };
 
   var expandAlias = function(name) {
-    return aliases[name] ? expandAlias(aliases[name]) : name;
+    return (aliases[name] && name !== aliases[name]) ? expandAlias(aliases[name]) : name;
   };
 
   var _resolve = function(name, dep) {


### PR DESCRIPTION
Avoid self-referential aliases for packages that have multiple namespaces pointing to the same module path.

Fixing https://github.com/brunch/brunch/issues/1844